### PR TITLE
Fix: Address React errors and accessibility warnings

### DIFF
--- a/components/CallList.tsx
+++ b/components/CallList.tsx
@@ -41,6 +41,7 @@ const CallList = ({ type }: { type: 'ended' | 'upcoming' | 'recordings' }) => {
   };
 
   useEffect(() => {
+    let isMounted = true;
     const fetchRecordings = async () => {
       const callData = await Promise.all(
         callRecordings?.map((meeting) => meeting.queryRecordings()) ?? [],
@@ -50,12 +51,18 @@ const CallList = ({ type }: { type: 'ended' | 'upcoming' | 'recordings' }) => {
         .filter((call) => call.recordings.length > 0)
         .flatMap((call) => call.recordings);
 
-      setRecordings(recordings);
+      if (isMounted) {
+        setRecordings(recordings);
+      }
     };
 
     if (type === 'recordings') {
       fetchRecordings();
     }
+
+    return () => {
+      isMounted = false;
+    };
   }, [type, callRecordings]);
 
   if (isLoading) return <Loader />;

--- a/components/MeetingModal.tsx
+++ b/components/MeetingModal.tsx
@@ -35,7 +35,7 @@ const MeetingModal = ({isOpen, onClose, title, className, children, handleClick,
               <Image src={image} width={72} height={72} alt='image'/>
             </div>
           )}
-          <h1 className={cn('text-3xl font-bold leading-[42px]', className)}>{title}</h1> 
+          <DialogTitle className={cn('text-3xl font-bold leading-[42px]', className)}>{title}</DialogTitle>
           {children}
           <Button className='bg-blue-1 focus-visible:ring-0 focus-visible:ring-offset-0' onClick={handleClick}>
             {buttonIcon && (


### PR DESCRIPTION
- I've updated MeetingModal.tsx to use DialogTitle for improved accessibility, resolving a warning from Radix UI. The h1 tag was replaced with the DialogTitle component.

- I've patched CallList.tsx to prevent React error #185 (setState on unmounted component). I added a cleanup function to the useEffect hook that fetches recordings. This ensures that state updates only occur if the component is still mounted, preventing errors when the component unmounts during an asynchronous operation.